### PR TITLE
Enforce pyproject.toml version bump on PRs

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -11,27 +11,29 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Determine if PR is docs-only
+      - name: Determine if PR requires a version bump
         id: scope
         run: |
+          set -euo pipefail
           base="${{ github.base_ref }}"
           git fetch --no-tags origin "$base"
           changed=$(git diff --name-only "origin/$base"...HEAD)
           echo "Changed files:"
           echo "$changed"
-          non_docs=$(echo "$changed" | grep -vE '^(docs/|.*\.md$)' || true)
-          if [ -z "$non_docs" ]; then
-            echo "docs_only=true" >> "$GITHUB_OUTPUT"
+          needs_bump=$(echo "$changed" | grep -vE '^(docs/|tests/|\.github/|.*\.md$)' || true)
+          if [ -z "$needs_bump" ]; then
+            echo "skip_bump=true" >> "$GITHUB_OUTPUT"
           else
-            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            echo "skip_bump=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Check pyproject.toml version was bumped
-        if: steps.scope.outputs.docs_only == 'false'
+        if: steps.scope.outputs.skip_bump == 'false'
         run: |
+          set -euo pipefail
           base="${{ github.base_ref }}"
-          base_ver=$(git show "origin/$base:pyproject.toml" | grep -E '^version = ' | head -1 | sed -E 's/version = "([^"]+)"/\1/')
-          head_ver=$(grep -E '^version = ' pyproject.toml | head -1 | sed -E 's/version = "([^"]+)"/\1/')
+          base_ver=$(git show "origin/$base:pyproject.toml" | python3 -c 'import sys, tomllib; print(tomllib.loads(sys.stdin.read())["project"]["version"])')
+          head_ver=$(python3 -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')
           echo "Base version: $base_ver"
           echo "HEAD version: $head_ver"
           if [ "$base_ver" = "$head_ver" ]; then
@@ -40,5 +42,5 @@ jobs:
           fi
 
       - name: Skip reason
-        if: steps.scope.outputs.docs_only == 'true'
-        run: echo "::notice::PR touches only docs/ and/or *.md — version bump not required."
+        if: steps.scope.outputs.skip_bump == 'true'
+        run: echo "::notice::PR touches only docs/, tests/, .github/, and/or *.md — version bump not required."

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -15,7 +15,7 @@ jobs:
         id: scope
         run: |
           base="${{ github.base_ref }}"
-          git fetch --no-tags --depth=0 origin "$base"
+          git fetch --no-tags origin "$base"
           changed=$(git diff --name-only "origin/$base"...HEAD)
           echo "Changed files:"
           echo "$changed"

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,44 @@
+name: Version bump
+
+on:
+  pull_request:
+
+jobs:
+  version-bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine if PR is docs-only
+        id: scope
+        run: |
+          base="${{ github.base_ref }}"
+          git fetch --no-tags --depth=0 origin "$base"
+          changed=$(git diff --name-only "origin/$base"...HEAD)
+          echo "Changed files:"
+          echo "$changed"
+          non_docs=$(echo "$changed" | grep -vE '^(docs/|.*\.md$)' || true)
+          if [ -z "$non_docs" ]; then
+            echo "docs_only=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check pyproject.toml version was bumped
+        if: steps.scope.outputs.docs_only == 'false'
+        run: |
+          base="${{ github.base_ref }}"
+          base_ver=$(git show "origin/$base:pyproject.toml" | grep -E '^version = ' | head -1 | sed -E 's/version = "([^"]+)"/\1/')
+          head_ver=$(grep -E '^version = ' pyproject.toml | head -1 | sed -E 's/version = "([^"]+)"/\1/')
+          echo "Base version: $base_ver"
+          echo "HEAD version: $head_ver"
+          if [ "$base_ver" = "$head_ver" ]; then
+            echo "::error title=Version not bumped::pyproject.toml version is still $head_ver on this PR. Bump it (patch for fixes, minor for features) — see CLAUDE.md."
+            exit 1
+          fi
+
+      - name: Skip reason
+        if: steps.scope.outputs.docs_only == 'true'
+        run: echo "::notice::PR touches only docs/ and/or *.md — version bump not required."

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -3,6 +3,9 @@ name: Version bump
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   version-bump:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rp"
-version = "0.8.11"
+version = "0.8.12"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rp"
-version = "0.8.12"
+version = "0.8.13"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rp"
-version = "0.8.13"
+version = "0.8.12"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -1251,7 +1251,7 @@ wheels = [
 
 [[package]]
 name = "rp"
-version = "0.8.12"
+version = "0.8.13"
 source = { editable = "." }
 dependencies = [
     { name = "pycares" },

--- a/uv.lock
+++ b/uv.lock
@@ -1251,7 +1251,7 @@ wheels = [
 
 [[package]]
 name = "rp"
-version = "0.8.13"
+version = "0.8.12"
 source = { editable = "." }
 dependencies = [
     { name = "pycares" },

--- a/uv.lock
+++ b/uv.lock
@@ -1251,7 +1251,7 @@ wheels = [
 
 [[package]]
 name = "rp"
-version = "0.8.11"
+version = "0.8.12"
 source = { editable = "." }
 dependencies = [
     { name = "pycares" },


### PR DESCRIPTION
## Summary
- New workflow `.github/workflows/version-bump.yml` that diffs `pyproject.toml`'s `version` between the PR branch and the base branch, failing if unchanged.
- Docs-only PRs (only `*.md` or files under `docs/`) are detected inside the job and pass without requiring a bump.
- Job always runs (no `paths-ignore`), so it can be added as a required check in branch protection without running into the skipped-required-check deadlock.

## Test plan
- [x] Workflow YAML validates
- [x] This PR itself bumps the version (0.8.11 → 0.8.12), so the required-bump path should go green on it
- [ ] After merge, add `version-bump` as a required status check in branch protection alongside `test` and `check`