### PR TITLE
Add E2E tests for rp up / rp run primary flows

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,6 +21,21 @@ jobs:
       - name: Sync dependencies
         run: uv sync --all-extras
 
+      - name: Configure SSH for pod access
+        env:
+          CI_SSH_PRIVATE_KEY: ${{ secrets.CI_SSH_PRIVATE_KEY }}
+        run: |
+          if [ -n "${CI_SSH_PRIVATE_KEY:-}" ]; then
+            mkdir -p ~/.ssh
+            chmod 700 ~/.ssh
+            printf '%s\n' "$CI_SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
+            chmod 600 ~/.ssh/id_ed25519
+            echo "RP_E2E_SSH_AVAILABLE=1" >> "$GITHUB_ENV"
+            echo "SSH key installed from CI_SSH_PRIVATE_KEY."
+          else
+            echo "CI_SSH_PRIVATE_KEY not set — tests requiring SSH to pods will be skipped."
+          fi
+
       - name: Run E2E tests
         env:
           RUNPOD_API_KEY: ${{ secrets.RUNPOD_API_KEY }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rp"
-version = "0.8.13"
+version = "0.8.14"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/tests/e2e/test_primary_flows.py
+++ b/tests/e2e/test_primary_flows.py
@@ -1,0 +1,96 @@
+"""End-to-end tests for primary rp flows: `rp up`, `rp run`, auto-shutdown.
+
+These exercise the paths users actually take (opinionated managed setup +
+remote command execution) and cost more per run than the bare-pod suite,
+so tests share one managed pod via a module-scoped fixture.
+
+They need the runner to be able to SSH into the pod (root@<ip>). Locally
+that works if your SSH key is registered with your RunPod account. In CI,
+the skip guard keeps the module inert until a `CI_SSH_PRIVATE_KEY` secret
+is configured and the e2e workflow installs it into the runner.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import uuid
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("GITHUB_ACTIONS") == "true"
+    and os.environ.get("RP_E2E_SSH_AVAILABLE") != "1",
+    reason="CI runner has no SSH key for pod access (set CI_SSH_PRIVATE_KEY secret to enable)",
+)
+
+CHEAP_GPUS: tuple[str, ...] = (
+    "1xRTX A4000",
+    "1xRTX 3090",
+    "1xRTX A5000",
+    "1xRTX 4090",
+    "1xRTX 5090",
+)
+
+
+@pytest.fixture(scope="module")
+def managed_pod(cli_runner):
+    """Create a managed pod via `rp up`, yield the alias, tear down with `rp down`."""
+    alias = f"test-e2e-managed-{uuid.uuid4().hex[:8]}"
+    last_result = None
+    for gpu in CHEAP_GPUS:
+        result = cli_runner(["up", "--gpu", gpu, "--storage", "0GB", "--alias", alias])
+        last_result = result
+        if result.returncode == 0:
+            break
+        if "no longer any instances" not in result.stderr.lower() and (
+            "unavailable" not in result.stderr.lower()
+        ):
+            raise AssertionError(f"rp up failed on {gpu}: {result.stderr}")
+    else:
+        raise AssertionError(
+            f"rp up failed across all cheap GPUs: "
+            f"{last_result.stderr if last_result else 'no result'}"
+        )
+
+    try:
+        yield alias
+    finally:
+        # Best-effort teardown — the sweep will catch it if this fails.
+        cli_runner(["down", alias, "--skip-logs"])
+
+
+class TestManagedPodFlow:
+    """Exercise the opinionated `rp up` path end to end."""
+
+    def test_auto_shutdown_installed(self, managed_pod):
+        """`rp up` must install the auto-shutdown script and cron on the pod.
+
+        Regression guard for the packaging bug where auto_shutdown.sh was
+        silently missing from the installed wheel — `rp up` reported
+        success but the pod had no auto-shutdown, leaking compute.
+        """
+        result = subprocess.run(
+            [
+                "ssh",
+                "-o",
+                "StrictHostKeyChecking=no",
+                "-o",
+                "ConnectTimeout=15",
+                managed_pod,
+                "test -x /usr/local/bin/auto_shutdown.sh && crontab -l | grep -q auto_shutdown.sh && echo OK",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+        )
+        assert result.returncode == 0 and "OK" in result.stdout, (
+            f"Auto-shutdown setup missing on pod. stdout={result.stdout!r} stderr={result.stderr!r}"
+        )
+
+    def test_rp_run_roundtrip(self, cli_runner, managed_pod):
+        """`rp run <alias> -- <cmd>` should execute on the pod and return output."""
+        result = cli_runner(["run", managed_pod, "--", "echo", "e2e-hello-world"])
+        assert result.returncode == 0, f"rp run failed: {result.stderr}"
+        assert "e2e-hello-world" in result.stdout

--- a/uv.lock
+++ b/uv.lock
@@ -1745,7 +1745,7 @@ wheels = [
 
 [[package]]
 name = "rp"
-version = "0.8.13"
+version = "0.8.14"
 source = { editable = "." }
 dependencies = [
     { name = "pycares" },


### PR DESCRIPTION
## Summary
Adds two high-signal E2E tests in `tests/e2e/test_primary_flows.py`:

- **`test_auto_shutdown_installed`** — after `rp up`, SSH into the pod and verify `/usr/local/bin/auto_shutdown.sh` exists and `crontab -l` references it. This is the specific regression guard for the packaging bug where the script was silently missing from the installed wheel; `rp up` claimed success while the pod had no auto-shutdown cron, leaking compute.
- **`test_rp_run_roundtrip`** — `rp run <alias> -- echo ...` must execute on the pod and return the expected output. Exercises the most-used command in the `/runpod` skill.

Both tests share a module-scoped `managed_pod` fixture that creates a pod via `rp up` (across cheap GPUs with the same fallback list as the lifecycle test) and tears down via `rp down`. One managed-pod lifecycle per run.

## Required follow-up to enable in CI
These tests SSH into the pod as root, so they need a private key whose public half is registered on the RunPod account. The e2e workflow now:
- Writes `secrets.CI_SSH_PRIVATE_KEY` into `~/.ssh/id_ed25519`.
- Sets `RP_E2E_SSH_AVAILABLE=1` when the key is present.

Until the secret is added, the module is skipped on CI (`pytestmark = pytest.mark.skipif(...)`). To enable:
1. Generate an ed25519 keypair dedicated to CI.
2. Add the public key to your RunPod account (Settings → SSH public keys).
3. Add the private key to the repo as secret `CI_SSH_PRIVATE_KEY`.
4. Next e2e run picks it up; tests auto-enable.

Locally the tests just run — they assume your personal key is already registered with your RunPod account.

## Test plan
- [x] Unit tests, lint, ty: green
- [ ] Before merging: user decides whether to provision `CI_SSH_PRIVATE_KEY` now or later (tests are inert-but-harmless without it)
- [ ] On merge, next `gh workflow run e2e.yml` exercises the added tests (if key is configured)