### PR TITLE
Make E2E primary-flow tests pass in CI

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,7 +79,10 @@ def cli_runner():
     """
 
     def run_command(
-        cmd_args: list[str], input_text: str | None = None, env: dict | None = None
+        cmd_args: list[str],
+        input_text: str | None = None,
+        env: dict | None = None,
+        timeout: int = 300,
     ) -> subprocess.CompletedProcess:
         """Run the rp command with given arguments."""
         full_env = os.environ.copy()
@@ -93,7 +96,7 @@ def cli_runner():
             text=True,
             capture_output=True,
             env=full_env,
-            timeout=300,
+            timeout=timeout,
         )
         return result
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,9 +70,13 @@ def temp_config_dir():
         cli_utils.API_KEY_FILE = config.API_KEY_FILE
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def cli_runner():
-    """Provide a CLI test runner."""
+    """Provide a CLI test runner.
+
+    Session-scoped because the returned callable holds no per-test state,
+    and module-scoped fixtures (e.g. `managed_pod`) need to depend on it.
+    """
 
     def run_command(
         cmd_args: list[str], input_text: str | None = None, env: dict | None = None

--- a/tests/e2e/test_primary_flows.py
+++ b/tests/e2e/test_primary_flows.py
@@ -39,7 +39,13 @@ def managed_pod(cli_runner):
     alias = f"test-e2e-managed-{uuid.uuid4().hex[:8]}"
     last_result = None
     for gpu in CHEAP_GPUS:
-        result = cli_runner(["up", "--gpu", gpu, "--storage", "0GB", "--alias", alias])
+        # `rp up` provisions a pod, installs tools, injects secrets, and
+        # deploys auto-shutdown — comfortably over the default 5-minute
+        # subprocess timeout on slower CI runners.
+        result = cli_runner(
+            ["up", "--gpu", gpu, "--storage", "0GB", "--alias", alias],
+            timeout=600,
+        )
         last_result = result
         if result.returncode == 0:
             break

--- a/tests/e2e/test_primary_flows.py
+++ b/tests/e2e/test_primary_flows.py
@@ -13,7 +13,6 @@ is configured and the e2e workflow installs it into the runner.
 from __future__ import annotations
 
 import os
-import subprocess
 import uuid
 
 import pytest
@@ -69,27 +68,27 @@ def managed_pod(cli_runner):
 class TestManagedPodFlow:
     """Exercise the opinionated `rp up` path end to end."""
 
-    def test_auto_shutdown_installed(self, managed_pod):
+    def test_auto_shutdown_installed(self, cli_runner, managed_pod):
         """`rp up` must install the auto-shutdown script and cron on the pod.
 
         Regression guard for the packaging bug where auto_shutdown.sh was
         silently missing from the installed wheel — `rp up` reported
         success but the pod had no auto-shutdown, leaking compute.
+
+        Checks run via `rp run --root` so auth uses the same SSH path as
+        the tool itself (agent forwarding, SSH config) rather than a raw
+        ssh invocation that can auth-fail in CI even when `rp run` works.
         """
-        result = subprocess.run(
+        result = cli_runner(
             [
-                "ssh",
-                "-o",
-                "StrictHostKeyChecking=no",
-                "-o",
-                "ConnectTimeout=15",
+                "run",
+                "--root",
                 managed_pod,
+                "--",
+                "sh",
+                "-c",
                 "test -x /usr/local/bin/auto_shutdown.sh && crontab -l | grep -q auto_shutdown.sh && echo OK",
             ],
-            capture_output=True,
-            text=True,
-            timeout=60,
-            check=False,
         )
         assert result.returncode == 0 and "OK" in result.stdout, (
             f"Auto-shutdown setup missing on pod. stdout={result.stdout!r} stderr={result.stderr!r}"


### PR DESCRIPTION
## Summary
- Follow-up fixes to PR #5 — the E2E primary-flow tests landed but hit three issues the first time they ran in CI (workflow_dispatch on run 24828003260's predecessor).
- Promote `cli_runner` to session scope so the module-scoped `managed_pod` fixture can depend on it — pytest errored with `ScopeMismatch` before any primary-flow test could run.
- Add an optional `timeout` parameter to `cli_runner` and pass 600s from `managed_pod`. `rp up` (provision + setup + auto-shutdown deploy) can exceed the default 5-minute subprocess timeout on slower CI runners.
- Route `test_auto_shutdown_installed` through `rp run --root` instead of a raw `ssh <alias>` call. The raw call auth-failed in CI even though `rp run` on the same pod worked (`rp run` uses `ssh -A` / agent forwarding; the plain ssh path doesn't), so the test is now consistent with the real user-facing auth path.

Test-only changes; no version bump (tests/ only).

## Test plan
- [x] Full E2E workflow green on this branch: [run 24828003260](https://github.com/agencyenterprise/rp/actions/runs/24828003260) — all 8 tests pass
- [x] `uv run pytest tests/unit/` passes locally (73 passed)
- [x] `uv run pytest tests/e2e/test_primary_flows.py` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)