### PR TITLE
Pin AWS profile + default SSH identity to RunPod-Key-Go

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -219,6 +219,7 @@ Settings are defined in `.rp_settings.json` files at any directory level. Resolu
 {
   "person": "alex",
   "project": "ast",
+  "aws_profile": "amaranth-mfa",
   "secrets": ["HF_TOKEN", "WANDB_API_KEY"]
 }
 ```
@@ -228,6 +229,8 @@ All fields are optional. Place a file in `~` for global defaults, in a repo root
 **Template variables**: `person` and `project` feed into alias templates (e.g., `{project}_{person}_{i}` → `ast_alex_1`). `RP_`-prefixed environment variables still override settings values.
 
 **Secrets**: The `secrets` list names env vars whose values are stored in macOS Keychain. A project-level `.rp_settings.json` can override a global secret (e.g., a project-specific `HF_TOKEN`).
+
+**AWS profile**: `aws_profile` pins which AWS named profile is used when injecting AWS credentials into managed pods. Without it, `aws configure export-credentials` falls back to the shell's default profile, which may not match the project's AWS account. Setting this in a project-level `.rp_settings.json` keeps the right account's creds going to the pod regardless of the shell's `AWS_PROFILE`.
 
 ### Legacy Configuration
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rp"
-version = "0.8.14"
+version = "0.9.0"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/rp/config.py
+++ b/src/rp/config.py
@@ -22,6 +22,12 @@ SSH_CONFIG_FILE = Path.home() / ".ssh" / "config"
 # Marker prefix for SSH config
 MARKER_PREFIX = "# rp:managed"
 
+# Path to the RunPod SSH key created by `runpodctl`. Pods auto-inject all
+# account-level public keys at boot, so this private key works against any pod
+# the user creates. Pinning it via IdentitiesOnly avoids OpenSSH burning
+# MaxAuthTries on Touch-ID-gated agent keys before reaching it.
+RUNPOD_SSH_KEY_FILE = Path.home() / ".runpod" / "ssh" / "RunPod-Key-Go"
+
 # --- END CONFIGURATION ---
 
 

--- a/src/rp/core/models.py
+++ b/src/rp/core/models.py
@@ -11,6 +11,8 @@ from enum import StrEnum
 
 from pydantic import BaseModel, Field, field_validator
 
+from rp.config import RUNPOD_SSH_KEY_FILE
+
 
 class PodStatus(StrEnum):
     """Enumeration of possible pod statuses."""
@@ -142,7 +144,15 @@ class SSHConfig(BaseModel):
     hostname: str = Field(description="SSH hostname/IP")
     port: int = Field(ge=1, le=65535, description="SSH port")
     user: str = Field(default="root", description="SSH username")
-    identity_file: str | None = Field(default=None, description="SSH key file path")
+    # Default to the runpodctl-managed key. Pods auto-inject all account-level
+    # public keys at boot, so this private key works against every pod the
+    # user creates. Pinning it via IdentitiesOnly keeps OpenSSH from offering
+    # unrelated agent keys (e.g. Touch-ID-gated work keys) and tripping
+    # MaxAuthTries before the right key is tried.
+    identity_file: str | None = Field(
+        default_factory=lambda: str(RUNPOD_SSH_KEY_FILE),
+        description="SSH key file path (None disables IdentityFile in the block)",
+    )
 
     def to_ssh_block(self, updated_timestamp: str) -> list[str]:
         """Generate SSH config block lines."""

--- a/src/rp/core/pod_setup.py
+++ b/src/rp/core/pod_setup.py
@@ -5,6 +5,7 @@ creating a non-root user, injecting secrets, and deploying auto-shutdown.
 """
 
 import importlib.resources
+import os
 import subprocess
 import tempfile
 from pathlib import Path
@@ -86,8 +87,15 @@ class PodSetup:
         if oauth_token:
             lines.append(f"export CLAUDE_CODE_OAUTH_TOKEN={oauth_token}")
 
-        # AWS credentials (from aws CLI)
-        aws_creds = _get_aws_credentials()
+        # AWS credentials (from aws CLI). Use the profile pinned in
+        # .rp_settings.json when present so we don't silently inject the
+        # shell's default-profile creds into a project that expects another
+        # account.
+        aws_creds = _get_aws_credentials(profile=resolved.aws_profile)
+        if aws_creds and resolved.aws_profile:
+            self.console.print(
+                f"      AWS profile: [cyan]{resolved.aws_profile}[/cyan]"
+            )
         for key, value in aws_creds.items():
             lines.append(f"export {key}={value}")
 
@@ -328,14 +336,24 @@ def _get_claude_oauth_token() -> str | None:
         return None
 
 
-def _get_aws_credentials() -> dict[str, str]:
-    """Get AWS credentials from aws CLI."""
+def _get_aws_credentials(profile: str | None = None) -> dict[str, str]:
+    """Get AWS credentials from aws CLI.
+
+    When *profile* is provided, AWS_PROFILE is set in the subprocess env so
+    `aws configure export-credentials` returns creds for that named profile
+    instead of falling back to the shell's default. Avoids silently injecting
+    the wrong account into managed pods.
+    """
+    env = os.environ.copy()
+    if profile:
+        env["AWS_PROFILE"] = profile
     try:
         result = subprocess.run(
             ["aws", "configure", "export-credentials", "--format", "env-no-export"],
             capture_output=True,
             text=True,
             check=True,
+            env=env,
         )
         creds: dict[str, str] = {}
         for line in result.stdout.strip().split("\n"):

--- a/src/rp/core/settings.py
+++ b/src/rp/core/settings.py
@@ -25,6 +25,14 @@ class RpSettings(BaseModel):
     secrets: list[str] = Field(
         default_factory=list, description="Secret env var names managed at this level"
     )
+    aws_profile: str | None = Field(
+        default=None,
+        description=(
+            "AWS named profile to export credentials from when injecting AWS_* "
+            "vars into managed pods. Pins the project to a specific account so "
+            "rp doesn't silently fall back to the shell's default profile."
+        ),
+    )
 
 
 class ResolvedSecret:
@@ -53,11 +61,13 @@ class ResolvedSettings:
         project: str | None,
         secrets: list[ResolvedSecret],
         sources: list[Path],
+        aws_profile: str | None = None,
     ):
         self.person = person
         self.project = project
         self.secrets = secrets
         self.sources = sources  # settings files found, closest first
+        self.aws_profile = aws_profile
 
     def template_vars(self) -> dict[str, str]:
         """Return template variables for pod alias resolution."""
@@ -110,6 +120,7 @@ def resolve_settings(start: Path | None = None) -> ResolvedSettings:
 
     person: str | None = None
     project: str | None = None
+    aws_profile: str | None = None
     # Track secrets: name → ResolvedSecret (first/closest wins)
     seen_secrets: dict[str, ResolvedSecret] = {}
     sources: list[Path] = []
@@ -127,6 +138,8 @@ def resolve_settings(start: Path | None = None) -> ResolvedSettings:
             person = settings.person
         if project is None and settings.project is not None:
             project = settings.project
+        if aws_profile is None and settings.aws_profile is not None:
+            aws_profile = settings.aws_profile
 
         # Closest wins for same-named secrets
         for secret_name in settings.secrets:
@@ -141,6 +154,7 @@ def resolve_settings(start: Path | None = None) -> ResolvedSettings:
         project=project,
         secrets=secrets,
         sources=sources,
+        aws_profile=aws_profile,
     )
 
 

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -127,6 +127,36 @@ class TestSSHConfig:
         assert "pod_id=pod123" in block_text
         assert "2022-01-20T12:00:00Z" in block_text
 
+    def test_default_identity_file_is_runpod_key(self):
+        """SSHConfig defaults to the runpodctl-managed key so OpenSSH
+        doesn't burn MaxAuthTries on unrelated agent keys (e.g. Touch-ID-
+        gated work keys) before reaching the right one."""
+        config = SSHConfig(
+            alias="test-pod", pod_id="pod123", hostname="1.2.3.4", port=12345
+        )
+        assert config.identity_file is not None
+        assert config.identity_file.endswith("/.runpod/ssh/RunPod-Key-Go")
+
+        block_text = "".join(config.to_ssh_block("2022-01-20T12:00:00Z"))
+        assert "    IdentitiesOnly yes\n" in block_text
+        assert "    IdentityFile " in block_text
+
+    def test_explicit_identity_file_none_omits_block_lines(self):
+        """Passing identity_file=None (e.g. when re-parsing a legacy block
+        that has no IdentityFile) suppresses the IdentityFile/IdentitiesOnly
+        lines instead of falling back to the default."""
+        config = SSHConfig(
+            alias="test-pod",
+            pod_id="pod123",
+            hostname="1.2.3.4",
+            port=12345,
+            identity_file=None,
+        )
+        assert config.identity_file is None
+        block_text = "".join(config.to_ssh_block("2022-01-20T12:00:00Z"))
+        assert "IdentitiesOnly" not in block_text
+        assert "IdentityFile" not in block_text
+
     def test_invalid_port(self):
         """Test port validation."""
         with pytest.raises(ValueError):

--- a/tests/unit/test_pod_setup.py
+++ b/tests/unit/test_pod_setup.py
@@ -1,0 +1,57 @@
+"""Tests for pod_setup helpers."""
+
+import subprocess
+from unittest.mock import patch
+
+from rp.core.pod_setup import _get_aws_credentials
+
+
+class TestGetAwsCredentials:
+    def test_no_profile_uses_inherited_env(self):
+        """Without an explicit profile, AWS_PROFILE is whatever the parent
+        shell has set (or unset). We verify the subprocess env mirrors
+        os.environ rather than carrying an injected AWS_PROFILE."""
+        fake = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="AWS_ACCESS_KEY_ID=AKIA\nAWS_SECRET_ACCESS_KEY=secret\n",
+            stderr="",
+        )
+        with (
+            patch("rp.core.pod_setup.subprocess.run", return_value=fake) as run,
+            patch.dict("os.environ", {"AWS_PROFILE": "shell-default"}, clear=False),
+        ):
+            creds = _get_aws_credentials()
+        assert creds == {
+            "AWS_ACCESS_KEY_ID": "AKIA",
+            "AWS_SECRET_ACCESS_KEY": "secret",
+        }
+        assert run.call_args.kwargs["env"]["AWS_PROFILE"] == "shell-default"
+
+    def test_profile_overrides_aws_profile_env(self):
+        """An explicit profile sets AWS_PROFILE in the subprocess env so
+        the export-credentials call resolves to that named profile, even
+        if the user's shell has a different default selected."""
+        fake = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="AWS_ACCESS_KEY_ID=AKIA\n", stderr=""
+        )
+        with (
+            patch("rp.core.pod_setup.subprocess.run", return_value=fake) as run,
+            patch.dict("os.environ", {"AWS_PROFILE": "shell-default"}, clear=False),
+        ):
+            creds = _get_aws_credentials(profile="amaranth-mfa")
+        assert creds == {"AWS_ACCESS_KEY_ID": "AKIA"}
+        assert run.call_args.kwargs["env"]["AWS_PROFILE"] == "amaranth-mfa"
+
+    def test_returns_empty_on_aws_error(self):
+        """A failed `aws` call must not leak as a hard error during
+        secret injection — we tolerate missing/broken AWS setup."""
+        with patch(
+            "rp.core.pod_setup.subprocess.run",
+            side_effect=subprocess.CalledProcessError(1, "aws"),
+        ):
+            assert _get_aws_credentials() == {}
+
+    def test_returns_empty_when_aws_missing(self):
+        with patch("rp.core.pod_setup.subprocess.run", side_effect=FileNotFoundError):
+            assert _get_aws_credentials(profile="any") == {}

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -138,6 +138,46 @@ class TestResolveSettings:
         assert vars == {"person": "alex"}
         assert "project" not in vars
 
+    def test_aws_profile_single_file(self, tmp_path):
+        (tmp_path / ".rp_settings.json").write_text(
+            json.dumps({"aws_profile": "amaranth-mfa"})
+        )
+        resolved = resolve_settings(tmp_path)
+        assert resolved.aws_profile == "amaranth-mfa"
+
+    def test_aws_profile_default_none(self, tmp_path):
+        (tmp_path / ".rp_settings.json").write_text(json.dumps({"person": "alex"}))
+        resolved = resolve_settings(tmp_path)
+        assert resolved.aws_profile is None
+
+    def test_aws_profile_closest_wins(self, tmp_path):
+        parent = tmp_path / "parent"
+        child = parent / "child"
+        child.mkdir(parents=True)
+
+        (parent / ".rp_settings.json").write_text(
+            json.dumps({"aws_profile": "default"})
+        )
+        (child / ".rp_settings.json").write_text(
+            json.dumps({"aws_profile": "amaranth-mfa"})
+        )
+
+        resolved = resolve_settings(child)
+        assert resolved.aws_profile == "amaranth-mfa"
+
+    def test_aws_profile_inherited_from_parent(self, tmp_path):
+        parent = tmp_path / "parent"
+        child = parent / "child"
+        child.mkdir(parents=True)
+
+        (parent / ".rp_settings.json").write_text(
+            json.dumps({"aws_profile": "amaranth-mfa"})
+        )
+        (child / ".rp_settings.json").write_text(json.dumps({"project": "ast"}))
+
+        resolved = resolve_settings(child)
+        assert resolved.aws_profile == "amaranth-mfa"
+
 
 class TestFindNearestSettingsFile:
     def test_finds_in_current(self, tmp_path):


### PR DESCRIPTION
## Summary

Fixes two silent-failure modes that an agent hit during a managed-pod session:

- **Wrong AWS account injected silently.** `aws configure export-credentials` was being called with no profile context, so managed pods got whatever AWS_PROFILE the shell happened to have set (or the SDK default if unset). The result looked "set up" but `aws s3 ls` against the project bucket failed mid-sweep. Adds an `aws_profile` field to `.rp_settings.json` that pins the profile per-project, and echoes the profile name during injection so it's no longer invisible.
- **`rp run` / `rp scp` flaky with Touch-ID-gated agent keys.** rp-managed `Host` blocks had no `IdentityFile`, so OpenSSH fell back to the agent. A 1Password biometric-protected key tried before the RunPod key ate `MaxAuthTries` and the connection got booted before the right key was offered. Defaults `SSHConfig.identity_file` to `~/.runpod/ssh/RunPod-Key-Go` (runpodctl-managed account-level key, auto-injected on every pod), which routes through the existing `IdentitiesOnly yes` + `IdentityFile` codepath in `to_ssh_block()`. No changes needed in `rp run`/`rp scp` themselves — the SSH config block does the work.

Version bumped to 0.9.0.

## Test plan

- [x] `uv run pytest tests/unit -q` (83 passed)
- [x] `uv run ruff check src tests` clean
- [x] New unit tests for `aws_profile` resolution (closest-wins, default None, inheritance)
- [x] New unit tests for `_get_aws_credentials(profile=...)` setting AWS_PROFILE in subprocess env
- [x] New unit tests for `SSHConfig` defaulting to RunPod-Key-Go and emitting `IdentitiesOnly yes`
- [ ] Manual: `rp up` on a project with `aws_profile` set, confirm the right account's creds land in `/root/.rp-env`
- [ ] Manual: `rp run <alias> echo ok` succeeds with a Touch-ID-gated key in the agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)