### PR TITLE
Tests + docs for H200/B200/8xH100 templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ rp down h100-1
 
 ### Templates
 
-Built-in: `h100`, `2h100`, `4h100`, `5090`, `a40` (all 500GB container disk, no volume, using `{project}_{person}_{i}` naming).
+Built-in: `h100`, `2h100`, `4h100`, `8h100`, `h200`, `2h200`, `4h200`, `8h200`, `b200`, `2b200`, `4b200`, `8b200`, `5090`, `a40` (all 500GB container disk, no volume, using `{project}_{person}_{i}` naming).
 
 ```bash
 # Set naming variables in .rp_settings.json (or ~/.rp_settings.json for global)

--- a/docs.md
+++ b/docs.md
@@ -209,7 +209,7 @@ rp template create ml-nv --alias-pattern "{project}_{person}_{i}" --gpu 2xA100 -
 
 #### `rp template list` / `rp template delete <id>`
 
-List or delete templates. Built-in defaults: `h100`, `2h100`, `4h100`, `5090`, `a40` (all use `{project}_{person}_{i}` pattern).
+List or delete templates. Built-in defaults: `h100`, `2h100`, `4h100`, `8h100`, `h200`, `2h200`, `4h200`, `8h200`, `b200`, `2b200`, `4b200`, `8b200`, `5090`, `a40` (all use `{project}_{person}_{i}` pattern).
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rp"
-version = "0.10.0"
+version = "0.10.1"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/tests/unit/test_default_templates.py
+++ b/tests/unit/test_default_templates.py
@@ -1,0 +1,105 @@
+"""Unit tests for the built-in pod templates."""
+
+import pytest
+
+from rp.cli.utils import parse_gpu_spec, parse_storage_spec
+from rp.core.default_templates import (
+    DEFAULT_CONTAINER_DISK,
+    DEFAULT_IMAGE,
+    get_default_templates,
+    is_default_template,
+)
+from rp.core.models import PodTemplate
+
+EXPECTED_GPU_GRID = {
+    "h100": (1, "H100"),
+    "2h100": (2, "H100"),
+    "4h100": (4, "H100"),
+    "8h100": (8, "H100"),
+    "h200": (1, "H200"),
+    "2h200": (2, "H200"),
+    "4h200": (4, "H200"),
+    "8h200": (8, "H200"),
+    "b200": (1, "B200"),
+    "2b200": (2, "B200"),
+    "4b200": (4, "B200"),
+    "8b200": (8, "B200"),
+}
+
+
+class TestGPUGrid:
+    """The {1,2,4,8} x {H100, H200, B200} matrix should be available as built-ins."""
+
+    @pytest.mark.parametrize("identifier", EXPECTED_GPU_GRID.keys())
+    def test_template_exists(self, identifier: str):
+        templates = get_default_templates()
+        assert identifier in templates
+        assert isinstance(templates[identifier], PodTemplate)
+
+    @pytest.mark.parametrize("identifier,expected", list(EXPECTED_GPU_GRID.items()))
+    def test_gpu_spec_parses_to_expected_count_and_model(
+        self, identifier: str, expected: tuple[int, str]
+    ):
+        template = get_default_templates()[identifier]
+        spec = parse_gpu_spec(template.gpu_spec)
+        assert (spec.count, spec.model) == expected
+
+    @pytest.mark.parametrize("identifier", EXPECTED_GPU_GRID.keys())
+    def test_identifier_matches_gpu_spec(self, identifier: str):
+        """Identifier convention: '<count><model>' for >1, bare '<model>' for 1."""
+        template = get_default_templates()[identifier]
+        spec = parse_gpu_spec(template.gpu_spec)
+        if spec.count == 1:
+            assert identifier == spec.model.lower()
+        else:
+            assert identifier == f"{spec.count}{spec.model.lower()}"
+
+
+class TestDefaultsApplied:
+    """All built-in templates share the same shipped defaults."""
+
+    @pytest.fixture(scope="class")
+    def templates(self) -> dict[str, PodTemplate]:
+        return get_default_templates()
+
+    def test_all_use_default_image(self, templates: dict[str, PodTemplate]):
+        for ident, t in templates.items():
+            assert t.image == DEFAULT_IMAGE, ident
+
+    def test_all_use_zero_volume(self, templates: dict[str, PodTemplate]):
+        for ident, t in templates.items():
+            assert parse_storage_spec(t.storage_spec) == 0, ident
+
+    def test_all_use_default_container_disk(self, templates: dict[str, PodTemplate]):
+        expected = parse_storage_spec(DEFAULT_CONTAINER_DISK)
+        for ident, t in templates.items():
+            assert t.container_disk_spec is not None, ident
+            assert parse_storage_spec(t.container_disk_spec) == expected, ident
+
+    def test_all_use_project_person_alias_pattern(
+        self, templates: dict[str, PodTemplate]
+    ):
+        for ident, t in templates.items():
+            assert t.alias_template == "{project}_{person}_{i}", ident
+
+    def test_no_network_volume_attached(self, templates: dict[str, PodTemplate]):
+        for ident, t in templates.items():
+            assert t.network_volume_id is None, ident
+
+    def test_identifier_field_matches_dict_key(self, templates: dict[str, PodTemplate]):
+        for ident, t in templates.items():
+            assert t.identifier == ident
+
+
+class TestIsDefaultTemplate:
+    def test_recognises_grid_members(self):
+        for identifier in EXPECTED_GPU_GRID:
+            assert is_default_template(identifier)
+
+    def test_recognises_other_builtins(self):
+        assert is_default_template("5090")
+        assert is_default_template("a40")
+
+    def test_rejects_unknown_identifier(self):
+        assert not is_default_template("definitely-not-a-template")
+        assert not is_default_template("")

--- a/uv.lock
+++ b/uv.lock
@@ -1745,7 +1745,7 @@ wheels = [
 
 [[package]]
 name = "rp"
-version = "0.9.1"
+version = "0.10.1"
 source = { editable = "." }
 dependencies = [
     { name = "pycares" },


### PR DESCRIPTION
## Summary
- Adds `tests/unit/test_default_templates.py` covering the new {1,2,4,8} × {H100, H200, B200} grid: identifier convention, GPU spec parsing, and shared defaults (image, container disk, alias pattern, no volume).
- Updates `README.md` and `docs.md` to list all 14 built-in template ids.
- Patch bump 0.10.0 → 0.10.1 (no runtime behavior change).

The templates themselves shipped in 5a810ee on main; this PR backfills tests + docs.

## Test plan
- [x] `uv run pytest tests/unit/` — 151 passed
- [x] `ruff check` / `ruff format` clean (via pre-commit)
- [x] `ty check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)