### PR TITLE
Rename storage flags: --disk and --persistent-volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ rp down h100-1
 
 | Command | Description |
 |---|---|
-| `rp up [template] [--gpu SPEC --storage SIZE] [--alias NAME] [--network-volume ID]` | Create pod + install tools + inject secrets + deploy auto-shutdown |
+| `rp up [template] [--gpu SPEC] [--disk SIZE] [--persistent-volume SIZE] [--alias NAME] [--network-volume ID]` | Create pod + install tools + inject secrets + deploy auto-shutdown |
 | `rp claude <alias> [-p PROMPT] [-d DIR]` | Launch Claude in tmux on pod (autonomous or interactive) |
 | `rp status <alias>` | Check remote Claude progress and read report |
 | `rp logs <alias>` | Sync remote Claude logs locally |
@@ -62,7 +62,7 @@ rp down h100-1
 
 | Command | Description |
 |---|---|
-| `rp pod create [template] [--gpu --storage ...] [--alias]` | Create bare pod, run setup.sh |
+| `rp pod create [template] [--gpu] [--disk SIZE] [--persistent-volume SIZE] [--alias]` | Create bare pod, run setup.sh |
 | `rp pod start <alias>` | Resume stopped pod (re-injects secrets for managed pods) |
 | `rp pod stop <alias>` | Stop pod |
 | `rp pod destroy <alias> [-f]` | Terminate pod permanently |
@@ -87,7 +87,7 @@ rp pod create h100      # creates ast_alex_1, ast_alex_2, etc.
 RP_PROJECT=other rp pod create h100   # creates other_alex_1
 
 # Custom templates
-rp template create ml --alias-pattern "{project}_{person}_{i}" --gpu 2xA100 --storage 1TB
+rp template create ml --alias-pattern "{project}_{person}_{i}" --gpu 2xA100 --persistent-volume 1TB
 rp template list
 rp template delete ml
 ```

--- a/docs.md
+++ b/docs.md
@@ -19,7 +19,7 @@ API key priority: `RUNPOD_API_KEY` env var → macOS Keychain → interactive pr
 
 ### Opinionated Commands (Managed Pods)
 
-#### `rp up [template] [--alias NAME] [--gpu SPEC] [--storage SIZE] [--network-volume ID] [-f]`
+#### `rp up [template] [--alias NAME] [--gpu SPEC] [--disk SIZE] [--persistent-volume SIZE] [--network-volume ID] [-f]`
 
 Create a pod with full opinionated setup. This is the recommended way to create pods.
 
@@ -32,11 +32,12 @@ The tool-install step waits for cloud-init / unattended-upgrades to release the 
 When the requested GPU type is fully out of capacity, the error message includes the five closest-VRAM alternatives as copy-pasteable `rp up --gpu '<count>x<id>'` commands.
 
 ```bash
-rp up h100                              # from template
-rp up --gpu 2xH100 --storage 500GB     # explicit (alias auto-generated from settings)
-rp up --gpu 2xH100 --storage 500GB --alias my-pod  # explicit with custom alias
-rp up h100 --alias custom-name          # template with alias override
-rp up h100 --network-volume vol_abc123  # attach a network volume
+rp up h100                                       # from template
+rp up --gpu 2xH100                               # explicit (500GB disk, no persistent volume)
+rp up --gpu 2xH100 --disk 1TB                    # bigger container disk
+rp up --gpu 2xH100 --persistent-volume 500GB     # add a persistent volume at /workspace
+rp up h100 --alias custom-name                   # template with alias override
+rp up h100 --network-volume vol_abc123           # attach an existing network volume
 ```
 
 When no `--alias` is given (with or without a template), the alias is auto-generated from `{project}_{person}_{i}` using variables from `.rp_settings.json`.
@@ -140,16 +141,18 @@ If no alias is detected in the arguments, an interactive pod selector is shown.
 
 All low-level pod management commands live under the `rp pod` subcommand.
 
-#### `rp pod create [template] [--alias NAME] [--gpu SPEC] [--storage SIZE] [--container-disk SIZE] [--image IMAGE] [--network-volume ID] [-f] [--dry-run]`
+#### `rp pod create [template] [--alias NAME] [--gpu SPEC] [--disk SIZE] [--persistent-volume SIZE] [--image IMAGE] [--network-volume ID] [-f] [--dry-run]`
 
 Create a bare pod, add alias, wait for SSH, run `~/.config/rp/setup.sh`. No secret injection or auto-shutdown. Use `rp up` for full managed setup.
 
+`--disk` sets the ephemeral container disk (default: 500GB). `--persistent-volume` adds a per-pod persistent volume mounted at `/workspace` (default: 0GB / no volume) — survives stop/start, deleted on destroy. `--network-volume` attaches an existing shared network volume at `/workspace` and overrides `--persistent-volume`.
+
 ```bash
-rp pod create --gpu 2xA100 --storage 500GB  # alias auto-generated from settings
-rp pod create --gpu 2xA100 --storage 500GB --alias my-pod  # explicit alias
-rp pod create h100                          # from template (auto-numbered alias)
-rp pod create h100 --alias custom-name      # template with alias override
-rp pod create --gpu H100 --storage 0GB --network-volume vol_abc123
+rp pod create --gpu 2xA100                              # 500GB disk, no persistent volume
+rp pod create --gpu 2xA100 --disk 1TB --alias my-pod    # bigger disk, explicit alias
+rp pod create h100                                      # from template (auto-numbered alias)
+rp pod create h100 --alias custom-name                  # template with alias override
+rp pod create --gpu H100 --network-volume vol_abc123    # attach an existing network volume
 ```
 
 #### `rp pod start <alias>`
@@ -198,13 +201,15 @@ The GPU ID or display name substring can be used as the `--gpu` argument in `rp 
 
 ### Templates
 
-#### `rp template create <id> --alias-pattern PATTERN --gpu SPEC --storage SIZE [--container-disk SIZE] [--image IMAGE] [--network-volume ID] [-f]`
+#### `rp template create <id> --alias-pattern PATTERN --gpu SPEC [--disk SIZE] [--persistent-volume SIZE] [--image IMAGE] [--network-volume ID] [-f]`
 
 Create a reusable pod template. Pattern must contain `{i}` placeholder for auto-numbering. Can also include variable placeholders like `{project}` and `{person}` that are resolved from `~/.config/rp/.env` or `RP_`-prefixed environment variables.
 
+`--disk` defaults to `500GB`; `--persistent-volume` defaults to `0GB` (no volume). Override either at `rp up` / `rp pod create` time with the same flag names.
+
 ```bash
-rp template create ml --alias-pattern "{project}_{person}_{i}" --gpu 2xA100 --storage 1TB
-rp template create ml-nv --alias-pattern "{project}_{person}_{i}" --gpu 2xA100 --storage 0GB --network-volume vol_abc123
+rp template create ml --alias-pattern "{project}_{person}_{i}" --gpu 2xA100 --persistent-volume 1TB
+rp template create ml-nv --alias-pattern "{project}_{person}_{i}" --gpu 2xA100 --network-volume vol_abc123
 ```
 
 #### `rp template list` / `rp template delete <id>`
@@ -297,7 +302,7 @@ Edge case: `x` in model name (e.g., `rtx4090`) is fine — only treated as count
 
 ### Network Volumes
 
-RunPod network volumes are persistent storage that can be shared across pods and survive pod termination. Pass a network volume ID via `--network-volume` to attach one at `/workspace`. When a network volume is specified, it takes precedence over the `--storage` volume parameter (set `--storage 0GB` to avoid allocating a separate pod volume).
+RunPod network volumes are persistent storage that can be shared across pods and survive pod termination. Pass a network volume ID via `--network-volume` to attach one at `/workspace`. When a network volume is specified, it takes precedence over `--persistent-volume` — leave `--persistent-volume` at its default (0GB) to avoid allocating a separate per-pod volume.
 
 Network volume IDs can be found in the RunPod web console under Storage. Templates can include a `network_volume_id` to automatically attach a volume to all pods created from that template.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rp"
-version = "0.10.0"
+version = "0.11.0"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/rp/cli/commands.py
+++ b/src/rp/cli/commands.py
@@ -106,8 +106,8 @@ def _resolve_default_alias(pod_manager: PodManager) -> str:
 def create_command(  # noqa: PLR0915  # Function complexity acceptable for main command
     alias: str | None = None,
     gpu: str | None = None,
-    storage: str | None = None,
-    container_disk: str | None = None,
+    persistent_volume: str | None = None,
+    disk: str | None = None,
     template: str | None = None,
     image: str | None = None,
     force: bool = False,
@@ -120,9 +120,9 @@ def create_command(  # noqa: PLR0915  # Function complexity acceptable for main 
         pod_manager = get_pod_manager()
 
         # Validate arguments
-        if not template and not (gpu and storage):
+        if not template and not gpu:
             raise ValueError(
-                "Must specify either a template (as first argument) or --gpu and --storage"
+                "Must specify either a template (as first argument) or --gpu"
             )
 
         if template:
@@ -181,17 +181,18 @@ def create_command(  # noqa: PLR0915  # Function complexity acceptable for main 
         else:
             # Use direct specification mode
             assert gpu is not None
-            assert storage is not None
 
             if not alias:
                 alias = _resolve_default_alias(pod_manager)
 
             gpu_spec = parse_gpu_spec(gpu)
-            volume_gb = parse_storage_spec(storage)
-
-            container_disk_gb = (
-                parse_storage_spec(container_disk) if container_disk is not None else 20
+            volume_gb = (
+                parse_storage_spec(persistent_volume)
+                if persistent_volume is not None
+                else 0
             )
+
+            container_disk_gb = parse_storage_spec(disk) if disk is not None else 500
 
             request = PodCreateRequest(
                 alias=alias,
@@ -289,7 +290,8 @@ def up_command(
     template: str | None = None,
     alias: str | None = None,
     gpu: str | None = None,
-    storage: str | None = None,
+    disk: str | None = None,
+    persistent_volume: str | None = None,
     force: bool = False,
     network_volume: str | None = None,
 ) -> None:
@@ -297,8 +299,15 @@ def up_command(
     try:
         pod_manager = get_pod_manager()
 
-        if not template and not (gpu and storage):
-            raise ValueError("Must specify either a template or --gpu and --storage")
+        if not template and not gpu:
+            raise ValueError("Must specify either a template or --gpu")
+
+        disk_gb = parse_storage_spec(disk) if disk is not None else None
+        volume_gb = (
+            parse_storage_spec(persistent_volume)
+            if persistent_volume is not None
+            else None
+        )
 
         # Create the pod using existing create logic
         if template:
@@ -319,22 +328,23 @@ def up_command(
                     dry_run=False,
                     alias_override=alias,
                     network_volume_id=network_volume,
+                    container_disk_gb_override=disk_gb,
+                    volume_gb_override=volume_gb,
                 )
                 progress.update(task, description="Pod created successfully")
             final_alias = pod.alias
         else:
             assert gpu is not None
-            assert storage is not None
 
             if not alias:
                 alias = _resolve_default_alias(pod_manager)
 
             gpu_spec = parse_gpu_spec(gpu)
-            volume_gb = parse_storage_spec(storage)
             request = PodCreateRequest(
                 alias=alias,
                 gpu_spec=gpu_spec,
-                volume_gb=volume_gb,
+                volume_gb=volume_gb if volume_gb is not None else 0,
+                container_disk_gb=disk_gb if disk_gb is not None else 500,
                 force=force,
                 network_volume_id=network_volume,
             )
@@ -762,8 +772,8 @@ def template_create_command(
     identifier: str,
     alias_template: str,
     gpu: str,
-    storage: str,
-    container_disk: str | None = None,
+    persistent_volume: str = "0GB",
+    disk: str = "500GB",
     image: str | None = None,
     network_volume: str | None = None,
     force: bool = False,
@@ -774,11 +784,9 @@ def template_create_command(
             "identifier": identifier,
             "alias_template": alias_template,
             "gpu_spec": gpu,
-            "storage_spec": storage,
+            "storage_spec": persistent_volume,
+            "container_disk_spec": disk,
         }
-
-        if container_disk is not None:
-            template_kwargs["container_disk_spec"] = container_disk
 
         if image is not None:
             template_kwargs["image"] = image
@@ -794,9 +802,8 @@ def template_create_command(
         console.print(f"✅ Created template '[bold]{identifier}[/bold]'")
         console.print(f"   Alias template: {alias_template}")
         console.print(f"   GPU: {gpu}")
-        console.print(f"   Storage: {storage}")
-        if container_disk is not None:
-            console.print(f"   Container disk: {container_disk}")
+        console.print(f"   Disk: {disk}")
+        console.print(f"   Persistent volume: {persistent_volume}")
         if image is not None:
             console.print(f"   Image: {image}")
         if network_volume is not None:

--- a/src/rp/core/pod_manager.py
+++ b/src/rp/core/pod_manager.py
@@ -400,6 +400,8 @@ class PodManager:
         dry_run: bool = False,
         alias_override: str | None = None,
         network_volume_id: str | None = None,
+        container_disk_gb_override: int | None = None,
+        volume_gb_override: int | None = None,
     ) -> Pod:
         """Create a pod using a template, finding the next available alias index or using provided alias."""
         from rp.config import load_template_vars
@@ -425,13 +427,18 @@ class PodManager:
         from rp.cli.utils import parse_gpu_spec, parse_storage_spec
 
         gpu_spec = parse_gpu_spec(template.gpu_spec)
-        volume_gb = parse_storage_spec(template.storage_spec)
-
-        container_disk_gb = (
-            parse_storage_spec(template.container_disk_spec)
-            if template.container_disk_spec is not None
-            else 20
+        volume_gb = (
+            volume_gb_override
+            if volume_gb_override is not None
+            else parse_storage_spec(template.storage_spec)
         )
+
+        if container_disk_gb_override is not None:
+            container_disk_gb = container_disk_gb_override
+        elif template.container_disk_spec is not None:
+            container_disk_gb = parse_storage_spec(template.container_disk_spec)
+        else:
+            container_disk_gb = 20
         image = template.image or PodCreateRequest.model_fields["image"].default
         nv_id = network_volume_id or template.network_volume_id
 

--- a/src/rp/main.py
+++ b/src/rp/main.py
@@ -89,20 +89,30 @@ def up(
     ),
     alias: str = typer.Option(None, "--alias", help="SSH host alias to assign"),
     gpu: str = typer.Option(None, "--gpu", help="GPU spec like '2xA100'"),
-    storage: str = typer.Option(
-        None, "--storage", help="Volume size like '500GB' or '1TB'"
+    disk: str = typer.Option(
+        None,
+        "--disk",
+        help="Container disk size, e.g. '500GB' (ephemeral, deleted with the pod). "
+        "Overrides the template's container disk; defaults to template value or 500GB.",
+    ),
+    persistent_volume: str = typer.Option(
+        None,
+        "--persistent-volume",
+        help="Persistent volume size, e.g. '500GB' (mounted at /workspace, survives stop/start). "
+        "Overrides the template's volume; defaults to template value or 0GB (no volume).",
     ),
     network_volume: str = typer.Option(
         None,
         "--network-volume",
-        help="RunPod network volume ID to attach (mounted at /workspace)",
+        help="Existing RunPod network volume ID to attach (mounted at /workspace, "
+        "shared across pods). Overrides --persistent-volume.",
     ),
     force: bool = typer.Option(
         False, "--force", "-f", help="Overwrite alias if it exists"
     ),
 ):
     """Create a pod with full opinionated setup (tools, secrets, auto-shutdown)."""
-    up_command(template, alias, gpu, storage, force, network_volume)
+    up_command(template, alias, gpu, disk, persistent_volume, force, network_volume)
 
 
 @app.command()
@@ -249,11 +259,17 @@ def create(
         None, "--alias", help="SSH host alias to assign (e.g., alexs-machine)"
     ),
     gpu: str = typer.Option(None, "--gpu", help="GPU spec like '2xA100'"),
-    storage: str = typer.Option(
-        None, "--storage", help="Volume size like '500GB' or '1TB'"
+    disk: str = typer.Option(
+        None,
+        "--disk",
+        help="Container disk size, e.g. '500GB' (ephemeral, deleted with the pod). "
+        "Default: 500GB.",
     ),
-    container_disk: str = typer.Option(
-        None, "--container-disk", help="Container disk size like '20GB' (default: 20GB)"
+    persistent_volume: str = typer.Option(
+        None,
+        "--persistent-volume",
+        help="Persistent volume size, e.g. '500GB' (mounted at /workspace, survives stop/start). "
+        "Default: 0GB (no volume).",
     ),
     image: str = typer.Option(
         None,
@@ -263,7 +279,8 @@ def create(
     network_volume: str = typer.Option(
         None,
         "--network-volume",
-        help="RunPod network volume ID to attach (mounted at /workspace)",
+        help="Existing RunPod network volume ID to attach (mounted at /workspace, "
+        "shared across pods). Overrides --persistent-volume.",
     ),
     force: bool = typer.Option(
         False, "--force", "-f", help="Overwrite alias if it exists"
@@ -281,8 +298,8 @@ def create(
     create_command(
         alias,
         gpu,
-        storage,
-        container_disk,
+        persistent_volume,
+        disk,
         template,
         image,
         force,
@@ -407,11 +424,17 @@ def template_create(
         help="Alias pattern with {i} placeholder (e.g., 'alex-ast-{i}')",
     ),
     gpu: str = typer.Option(..., "--gpu", help="GPU spec like '2xA100'"),
-    storage: str = typer.Option(
-        ..., "--storage", help="Volume size like '500GB' or '1TB'"
+    disk: str = typer.Option(
+        "500GB",
+        "--disk",
+        help="Container disk size, e.g. '500GB' (ephemeral, deleted with the pod). "
+        "Default: 500GB.",
     ),
-    container_disk: str = typer.Option(
-        None, "--container-disk", help="Container disk size like '20GB' (default: 20GB)"
+    persistent_volume: str = typer.Option(
+        "0GB",
+        "--persistent-volume",
+        help="Persistent volume size, e.g. '500GB' (mounted at /workspace, survives stop/start). "
+        "Default: 0GB (no volume).",
     ),
     image: str = typer.Option(
         None,
@@ -421,7 +444,8 @@ def template_create(
     network_volume: str = typer.Option(
         None,
         "--network-volume",
-        help="RunPod network volume ID to attach to pods created from this template",
+        help="Existing RunPod network volume ID to attach to pods created from this template "
+        "(mounted at /workspace, shared across pods). Overrides --persistent-volume.",
     ),
     force: bool = typer.Option(
         False, "--force", "-f", help="Overwrite template if it exists"
@@ -432,8 +456,8 @@ def template_create(
         identifier,
         alias_pattern,
         gpu,
-        storage,
-        container_disk,
+        persistent_volume,
+        disk,
         image,
         network_volume,
         force,

--- a/tests/e2e/test_pod_lifecycle.py
+++ b/tests/e2e/test_pod_lifecycle.py
@@ -34,7 +34,7 @@ def _create_pod_with_fallback(cli_runner, alias: str, storage: str = "10GB"):
                 alias,
                 "--gpu",
                 gpu,
-                "--storage",
+                "--persistent-volume",
                 storage,
                 "--no-setup",
             ]

--- a/tests/e2e/test_primary_flows.py
+++ b/tests/e2e/test_primary_flows.py
@@ -42,7 +42,7 @@ def managed_pod(cli_runner):
         # deploys auto-shutdown — comfortably over the default 5-minute
         # subprocess timeout on slower CI runners.
         result = cli_runner(
-            ["up", "--gpu", gpu, "--storage", "0GB", "--alias", alias],
+            ["up", "--gpu", gpu, "--persistent-volume", "0GB", "--alias", alias],
             timeout=600,
         )
         last_result = result

--- a/tests/unit/test_storage_flags.py
+++ b/tests/unit/test_storage_flags.py
@@ -6,6 +6,7 @@ verify the typer surface advertises the new names, defaults are correct,
 and the old names produce a usage error rather than silently working.
 """
 
+import re
 from unittest.mock import MagicMock
 
 import pytest
@@ -23,11 +24,15 @@ app.add_typer(secrets_app, name="secrets")
 
 runner = CliRunner()
 
+# Typer/Rich styles each `-` as its own ANSI span, so `--disk` isn't a
+# contiguous substring of styled help output. Strip codes before asserting.
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
 
 def _help(args: list[str]) -> str:
     result = runner.invoke(app, [*args, "--help"])
     assert result.exit_code == 0, result.output
-    return result.output
+    return _ANSI_RE.sub("", result.output)
 
 
 class TestUpHelp:

--- a/tests/unit/test_storage_flags.py
+++ b/tests/unit/test_storage_flags.py
@@ -1,0 +1,219 @@
+"""CLI surface tests for the renamed storage flags.
+
+The old `--storage` and `--container-disk` flags were renamed to
+`--persistent-volume` and `--disk` (respectively) in 0.11.0. These tests
+verify the typer surface advertises the new names, defaults are correct,
+and the old names produce a usage error rather than silently working.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from typer.testing import CliRunner
+
+from rp.core.models import AppConfig, GPUSpec, PodCreateRequest, PodTemplate
+from rp.core.pod_manager import PodManager
+from rp.main import app, pod_app, secrets_app, template_app
+
+# Sub-apps are normally registered inside `main()`; tests need to do it
+# manually to invoke `rp pod create` / `rp template create` etc.
+app.add_typer(pod_app, name="pod")
+app.add_typer(template_app, name="template")
+app.add_typer(secrets_app, name="secrets")
+
+runner = CliRunner()
+
+
+def _help(args: list[str]) -> str:
+    result = runner.invoke(app, [*args, "--help"])
+    assert result.exit_code == 0, result.output
+    return result.output
+
+
+class TestUpHelp:
+    def test_advertises_new_flags(self):
+        out = _help(["up"])
+        assert "--disk" in out
+        assert "--persistent-volume" in out
+        assert "--network-volume" in out
+
+    def test_old_flag_absent_from_help(self):
+        out = _help(["up"])
+        assert "--storage" not in out
+
+
+class TestPodCreateHelp:
+    def test_advertises_new_flags(self):
+        out = _help(["pod", "create"])
+        assert "--disk" in out
+        assert "--persistent-volume" in out
+        assert "--network-volume" in out
+
+    def test_old_flags_absent_from_help(self):
+        out = _help(["pod", "create"])
+        assert "--storage" not in out
+        assert "--container-disk" not in out
+
+
+class TestTemplateCreateHelp:
+    def test_advertises_new_flags(self):
+        out = _help(["template", "create"])
+        assert "--disk" in out
+        assert "--persistent-volume" in out
+
+    def test_old_flags_absent_from_help(self):
+        out = _help(["template", "create"])
+        assert "--storage" not in out
+        assert "--container-disk" not in out
+
+    def test_persistent_volume_no_longer_required(self):
+        """Previously --storage was required on `rp template create`. After
+        the rename, --persistent-volume defaults to 0GB and is optional —
+        verified by the absence of an error when only --gpu/--alias-pattern
+        are provided. We invoke with a fake identifier and rely on a
+        downstream failure (no API key, etc.) — but typer itself must
+        accept the missing flag rather than reject as a usage error."""
+        result = runner.invoke(
+            app,
+            [
+                "template",
+                "create",
+                "test-tmpl-from-test",
+                "--alias-pattern",
+                "{i}",
+                "--gpu",
+                "h100",
+            ],
+        )
+        # Typer-level usage errors exit with code 2 and emit "Missing option".
+        # Anything else (including downstream failures we don't care about)
+        # means typer accepted the invocation.
+        if result.exit_code == 2:
+            assert "missing option" not in (result.output or "").lower()
+
+
+class TestRejectsOldFlags:
+    @pytest.mark.parametrize(
+        "argv",
+        [
+            ["up", "--storage", "100GB"],
+            ["pod", "create", "--storage", "100GB"],
+            ["pod", "create", "--container-disk", "100GB"],
+            [
+                "template",
+                "create",
+                "x",
+                "--alias-pattern",
+                "{i}",
+                "--gpu",
+                "h100",
+                "--storage",
+                "100GB",
+            ],
+            [
+                "template",
+                "create",
+                "x",
+                "--alias-pattern",
+                "{i}",
+                "--gpu",
+                "h100",
+                "--container-disk",
+                "100GB",
+            ],
+        ],
+    )
+    def test_old_flags_produce_usage_error(self, argv: list[str]):
+        result = runner.invoke(app, argv)
+        # Typer exits 2 with "No such option" when an unknown flag is given.
+        assert result.exit_code == 2
+        assert "no such option" in (result.output or "").lower()
+
+
+class TestCreatePodFromTemplateOverrides:
+    """`rp up --disk` / `--persistent-volume` need to override template values
+    via create_pod_from_template's new override params."""
+
+    def _template(self) -> PodTemplate:
+        return PodTemplate(
+            identifier="t",
+            alias_template="x_{i}",
+            gpu_spec="h100",
+            storage_spec="0GB",
+            container_disk_spec="500GB",
+        )
+
+    def _build(self, monkeypatch):
+        api = MagicMock()
+        api.find_gpu_type_ids.return_value = ["NVIDIA H100"]
+        pod_data = {
+            "id": "pod-1",
+            "name": "x_99",
+            "desiredStatus": "RUNNING",
+            "imageName": "img",
+            "machine": {"podHostId": "host"},
+            "runtime": {"ports": []},
+        }
+        api.create_pod.return_value = pod_data
+        api.wait_for_pod_ready.return_value = pod_data
+        pm = PodManager(api_client=api)
+        # Inject a pristine AppConfig with just our template, bypassing
+        # the user's real ~/.config/rp/pods.json on disk.
+        cfg = AppConfig()
+        cfg.pod_templates["t"] = self._template()
+        pm._config = cfg
+        monkeypatch.setattr(pm, "_save_config", lambda: None)
+        # _locked_config writes to disk; stub it to a no-op context manager
+        # that just yields the in-memory config.
+        from contextlib import contextmanager
+
+        @contextmanager
+        def fake_locked():
+            yield pm._config
+
+        monkeypatch.setattr(pm, "_locked_config", fake_locked)
+        return pm, api
+
+    def test_disk_override_takes_precedence_over_template(self, monkeypatch):
+        pm, api = self._build(monkeypatch)
+        pm.create_pod_from_template(
+            "t",
+            alias_override="x_99",
+            container_disk_gb_override=250,
+        )
+        kwargs = api.create_pod.call_args.kwargs
+        assert kwargs["container_disk_in_gb"] == 250
+
+    def test_persistent_volume_override_takes_precedence_over_template(
+        self, monkeypatch
+    ):
+        pm, api = self._build(monkeypatch)
+        pm.create_pod_from_template(
+            "t",
+            alias_override="x_99",
+            volume_gb_override=300,
+        )
+        kwargs = api.create_pod.call_args.kwargs
+        assert kwargs["volume_in_gb"] == 300
+
+    def test_no_override_uses_template_values(self, monkeypatch):
+        pm, api = self._build(monkeypatch)
+        pm.create_pod_from_template("t", alias_override="x_99")
+        kwargs = api.create_pod.call_args.kwargs
+        assert kwargs["container_disk_in_gb"] == 500
+        assert kwargs["volume_in_gb"] == 0
+
+
+class TestPodCreateRequestDefaults:
+    """The model still supports container_disk_gb=20 as its baked-in default.
+    The CLI now passes 500 explicitly (the new shipped default), but the
+    model field default is unchanged — so model-level callers (tests, API)
+    still see 20 unless overridden."""
+
+    def test_request_default_unchanged(self):
+        req = PodCreateRequest(
+            alias="a",
+            gpu_spec=GPUSpec(count=1, model="H100"),
+            volume_gb=0,
+        )
+        assert req.container_disk_gb == 20

--- a/uv.lock
+++ b/uv.lock
@@ -1745,7 +1745,7 @@ wheels = [
 
 [[package]]
 name = "rp"
-version = "0.9.1"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "pycares" },


### PR DESCRIPTION
## Summary

Renames the storage-related CLI flags across `rp up`, `rp pod create`, and `rp template create` for consistency and so the more common knob (container disk) sits on the shorter, more prominent flag name.

| Before | After |
|---|---|
| `--storage` | `--persistent-volume` (all three commands) |
| `--container-disk` | `--disk` (rp pod create, rp template create) |
| _no flag_ | `--disk` (rp up gains it) |

**`rp up`** now also exposes `--disk` and `--persistent-volume`, both of which override the template's values when given.

**`rp template create`** no longer requires `--persistent-volume` (defaults to `0GB`). `--disk` defaults to `500GB`.

**Defaults** reflect the philosophy that container disk is the standard knob; persistent volumes and network volumes are opt-in.

### Breaking changes

- Anyone scripting `rp up --storage 500GB` / `rp pod create --storage` / `rp template create --storage` / `--container-disk` will get a typer "No such option" error and need to update.
- `rp pod create --gpu X` (no template) now uses a 500GB container disk by default, up from 20GB. Matches templates and the new `--disk` default.

### Non-changes

- Internal model fields (`storage_spec`, `container_disk_spec` on `PodTemplate`; `volume_gb`, `container_disk_gb` on `PodCreateRequest`) are **unchanged**, so existing `~/.config/rp/pods.json` files keep working without migration.
- `--network-volume` is unchanged.

### Implementation notes

- `PodManager.create_pod_from_template` gained `container_disk_gb_override` and `volume_gb_override` so `rp up`'s new flags can override template values without mutating the stored template.
- `up_command` now plumbs disk + persistent-volume through to either path (template / direct).

Version bumped 0.10.0 → 0.11.0 (minor; breaking CLI change).

## Test plan
- [x] `uv run pytest tests/unit/` — 122 passed (16 new tests in tests/unit/test_storage_flags.py)
- [x] Pre-commit hooks pass (ruff, ruff-format, ty)
- [x] Spot-checked `rp up --help` / `rp pod create --help` / `rp template create --help` advertise the new flags
- [ ] E2E tests not run locally (require RUNPOD_API_KEY); two flag references in e2e tests updated to the new names

🤖 Generated with [Claude Code](https://claude.com/claude-code)