### PR TITLE
Notify when a newer rp is available on GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ uv tool install https://github.com/agencyenterprise/rp.git
 rp --install-completion  # optional tab completion
 ```
 
+After each command, `rp` checks GitHub for a newer version and prints a one-line upgrade hint on stderr when behind. The check is cached for 24h and silent on network errors. Set `RP_NO_VERSION_CHECK=1` to disable.
+
 ## Quick Start
 
 ```bash

--- a/docs.md
+++ b/docs.md
@@ -13,6 +13,10 @@ rp --install-completion  # optional tab completion
 
 API key priority: `RUNPOD_API_KEY` env var → macOS Keychain → interactive prompt (saves to Keychain).
 
+### Update notifications
+
+After each command, `rp` prints a one-line notice on stderr if a newer version is available on `main` of the GitHub repo. The check fetches `pyproject.toml` from `raw.githubusercontent.com` (no auth, public repo), caches the result for 24h in `~/.config/rp/version_check.json`, and degrades silently on any network or parse error. Set `RP_NO_VERSION_CHECK=1` to disable.
+
 ---
 
 ## Command Reference
@@ -250,6 +254,7 @@ The following files in `~/.config/rp/` are still supported:
 | `pods.json` | Aliases, pod metadata (including `managed` flag), templates |
 | `setup.sh` | Script run on bare pods during create/start |
 | `.env` | Legacy template variables (overridden by `.rp_settings.json`, overridden by `RP_` env vars) |
+| `version_check.json` | Cached result of the GitHub update check; refreshed every 24h |
 
 ### pods.json
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rp"
-version = "0.11.0"
+version = "0.12.0"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/rp/core/version_check.py
+++ b/src/rp/core/version_check.py
@@ -1,0 +1,176 @@
+"""Lightweight update notifier.
+
+Fetches the `version =` line from `pyproject.toml` on the default branch of
+the GitHub repo, caches the result for ~24h, and prints a one-line notice
+when a newer release is available. The check is best-effort: any network,
+parse, or filesystem error degrades silently so a flaky connection never
+breaks a `rp` command.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import re
+import tomllib
+import urllib.error
+import urllib.request
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+PYPROJECT_URL = (
+    "https://raw.githubusercontent.com/agencyenterprise/rp/main/pyproject.toml"
+)
+REPO_URL = "https://github.com/agencyenterprise/rp"
+DEFAULT_TIMEOUT_SECONDS = 2.0
+DEFAULT_MAX_AGE_HOURS = 24.0
+
+
+def _find_editable_repo_root() -> Path | None:
+    """If rp is installed editable from a git checkout, return that root.
+
+    Walks up from this file's location looking for a `.git` directory.
+    Returns None for wheel installs (where the source lives in site-packages).
+    """
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        if (parent / ".git").exists():
+            return parent
+    return None
+
+
+def _build_notice(installed: str, latest: str) -> str:
+    repo = _find_editable_repo_root()
+    if repo is not None:
+        upgrade = f"Run `cd {repo} && git pull && uv pip install -e .` to upgrade."
+    else:
+        upgrade = f"See {REPO_URL} for upgrade instructions."
+    return f"A new version of rp is available: {installed} → {latest}. {upgrade}"
+
+
+@dataclass(frozen=True)
+class CacheEntry:
+    checked_at: datetime
+    latest_version: str
+
+
+# ── parsing ──────────────────────────────────────────────────────────
+
+
+def parse_version_from_pyproject(toml_text: str) -> str | None:
+    """Return the [project].version string, or None if missing/unparseable."""
+    try:
+        data = tomllib.loads(toml_text)
+    except tomllib.TOMLDecodeError:
+        return None
+    version = data.get("project", {}).get("version")
+    return version if isinstance(version, str) else None
+
+
+_VERSION_RE = re.compile(r"^\d+(\.\d+)*$")
+
+
+def _parse_version_tuple(s: str) -> tuple[int, ...] | None:
+    """Parse a simple dotted-numeric version into a tuple. None on garbage.
+
+    Pre-release / local-version segments aren't supported because we don't
+    publish them — keeping this comparator minimal avoids pulling in
+    `packaging` as a runtime dep.
+    """
+    if not _VERSION_RE.match(s):
+        return None
+    return tuple(int(part) for part in s.split("."))
+
+
+def is_newer(latest: str, installed: str) -> bool:
+    """True iff `latest` parses as a strictly higher version than `installed`."""
+    a = _parse_version_tuple(latest)
+    b = _parse_version_tuple(installed)
+    if a is None or b is None:
+        return False
+    return a > b
+
+
+# ── cache ────────────────────────────────────────────────────────────
+
+
+def load_cache(path: Path) -> CacheEntry | None:
+    """Load a cache entry; return None if the file is missing or invalid."""
+    try:
+        raw = json.loads(path.read_text())
+        return CacheEntry(
+            checked_at=datetime.fromisoformat(raw["checked_at"]),
+            latest_version=raw["latest_version"],
+        )
+    except (OSError, ValueError, KeyError):
+        return None
+
+
+def save_cache(path: Path, version: str) -> None:
+    """Persist a cache entry stamped with the current time."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "checked_at": datetime.now().astimezone().isoformat(),
+        "latest_version": version,
+    }
+    path.write_text(json.dumps(payload))
+
+
+def is_cache_fresh(entry: CacheEntry, max_age_hours: float) -> bool:
+    age = datetime.now().astimezone() - entry.checked_at
+    return age.total_seconds() < max_age_hours * 3600
+
+
+# ── network ──────────────────────────────────────────────────────────
+
+
+def fetch_latest_version(timeout: float = DEFAULT_TIMEOUT_SECONDS) -> str | None:
+    """Fetch + parse pyproject.toml from the default branch. None on any error."""
+    try:
+        req = urllib.request.Request(
+            PYPROJECT_URL, headers={"User-Agent": "rp-version-check"}
+        )
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            body = resp.read().decode("utf-8", errors="replace")
+    except (urllib.error.URLError, OSError, TimeoutError):
+        return None
+    return parse_version_from_pyproject(body)
+
+
+# ── orchestration ────────────────────────────────────────────────────
+
+
+def check_for_updates(
+    installed_version: str,
+    cache_path: Path,
+    fetcher: Callable[[], str | None] = fetch_latest_version,
+    max_age_hours: float = DEFAULT_MAX_AGE_HOURS,
+) -> str | None:
+    """Return a one-line update notice, or None if up-to-date / unknown.
+
+    Never raises. Uses the cache when fresh; otherwise calls `fetcher` and
+    refreshes the cache on success.
+    """
+    try:
+        latest: str | None = None
+
+        cached = load_cache(cache_path)
+        if cached is not None and is_cache_fresh(cached, max_age_hours):
+            latest = cached.latest_version
+        else:
+            try:
+                latest = fetcher()
+            except Exception:
+                latest = None
+            if latest is not None:
+                with contextlib.suppress(OSError):
+                    save_cache(cache_path, latest)
+
+        if latest is None or not is_newer(latest, installed_version):
+            return None
+
+        return _build_notice(installed_version, latest)
+    except Exception:
+        return None

--- a/src/rp/main.py
+++ b/src/rp/main.py
@@ -6,7 +6,10 @@ Commands are split into two tiers:
 - `rp pod`: low-level pod management (create, start, stop, destroy, etc.)
 """
 
+import importlib.metadata
 import json
+import os
+import sys
 
 import typer
 
@@ -40,8 +43,47 @@ from rp.cli.commands import (
     up_command,
 )
 from rp.cli.utils import console
-from rp.config import POD_CONFIG_FILE
+from rp.config import CONFIG_DIR, POD_CONFIG_FILE
+from rp.core import version_check
 from rp.core.models import AppConfig
+
+VERSION_CACHE_FILE = CONFIG_DIR / "version_check.json"
+
+
+def _check_for_updates_safe() -> str | None:
+    """Wrapper around version_check.check_for_updates with the rp-specific defaults.
+
+    Split out so tests can stub it cleanly.
+    """
+    try:
+        installed = importlib.metadata.version("rp")
+    except importlib.metadata.PackageNotFoundError:
+        return None
+    return version_check.check_for_updates(
+        installed_version=installed,
+        cache_path=VERSION_CACHE_FILE,
+    )
+
+
+def _maybe_print_update_notice() -> None:
+    """Print an upgrade notice to stderr after a command finishes.
+
+    No-op when:
+    - RP_NO_VERSION_CHECK is set (CI / scripted use)
+    - typer is invoking shell completion (the _RP_COMPLETE protocol expects
+      a strict stdout/stderr contract; any extra output breaks it)
+    - the network/cache check yields nothing or raises
+    """
+    try:
+        if os.environ.get("RP_NO_VERSION_CHECK"):
+            return
+        if os.environ.get("_RP_COMPLETE"):
+            return
+        notice = _check_for_updates_safe()
+        if notice:
+            print(notice, file=sys.stderr)
+    except Exception:
+        return
 
 
 def complete_alias(incomplete: str) -> list[str]:
@@ -539,7 +581,10 @@ def main():
     app.add_typer(pod_app, name="pod")
     app.add_typer(template_app, name="template")
     app.add_typer(secrets_app, name="secrets")
-    app()
+    try:
+        app()
+    finally:
+        _maybe_print_update_notice()
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_version_check.py
+++ b/tests/unit/test_version_check.py
@@ -1,0 +1,335 @@
+"""Tests for the GitHub-backed version-update notifier."""
+
+from __future__ import annotations
+
+import json
+import time
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from rp.core import version_check
+
+# ── parse_version_from_pyproject ─────────────────────────────────────
+
+
+def test_parse_version_from_pyproject_extracts_version() -> None:
+    toml = '[project]\nname = "rp"\nversion = "1.2.3"\n'
+    assert version_check.parse_version_from_pyproject(toml) == "1.2.3"
+
+
+def test_parse_version_from_pyproject_returns_none_when_missing() -> None:
+    toml = '[project]\nname = "rp"\n'
+    assert version_check.parse_version_from_pyproject(toml) is None
+
+
+def test_parse_version_from_pyproject_returns_none_on_invalid_toml() -> None:
+    assert version_check.parse_version_from_pyproject("not [valid toml") is None
+
+
+# ── is_newer ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "latest,installed,expected",
+    [
+        ("0.12.0", "0.11.0", True),
+        ("0.11.1", "0.11.0", True),
+        ("1.0.0", "0.11.0", True),
+        ("0.11.0", "0.11.0", False),
+        ("0.11.0", "0.12.0", False),
+        ("0.10.0", "0.11.0", False),
+    ],
+)
+def test_is_newer(latest: str, installed: str, expected: bool) -> None:
+    assert version_check.is_newer(latest, installed) is expected
+
+
+def test_is_newer_returns_false_on_garbage() -> None:
+    # Robustness: a bad version string from a malformed remote pyproject
+    # should never crash the CLI.
+    assert version_check.is_newer("not-a-version", "0.11.0") is False
+
+
+# ── cache file ───────────────────────────────────────────────────────
+
+
+def test_save_and_load_cache_roundtrip(tmp_path: Path) -> None:
+    cache_path = tmp_path / "version_check.json"
+    version_check.save_cache(cache_path, "0.12.5")
+
+    entry = version_check.load_cache(cache_path)
+    assert entry is not None
+    assert entry.latest_version == "0.12.5"
+    assert isinstance(entry.checked_at, datetime)
+
+
+def test_load_cache_returns_none_when_file_missing(tmp_path: Path) -> None:
+    assert version_check.load_cache(tmp_path / "nope.json") is None
+
+
+def test_load_cache_returns_none_on_corrupt_file(tmp_path: Path) -> None:
+    cache_path = tmp_path / "version_check.json"
+    cache_path.write_text("{not valid json")
+    assert version_check.load_cache(cache_path) is None
+
+
+def test_is_cache_fresh_true_for_recent() -> None:
+    entry = version_check.CacheEntry(
+        checked_at=datetime.now().astimezone() - timedelta(hours=1),
+        latest_version="0.12.0",
+    )
+    assert version_check.is_cache_fresh(entry, max_age_hours=24.0) is True
+
+
+def test_is_cache_fresh_false_for_old() -> None:
+    entry = version_check.CacheEntry(
+        checked_at=datetime.now().astimezone() - timedelta(hours=48),
+        latest_version="0.12.0",
+    )
+    assert version_check.is_cache_fresh(entry, max_age_hours=24.0) is False
+
+
+# ── check_for_updates (orchestration) ────────────────────────────────
+
+
+def test_check_for_updates_returns_notice_when_newer(tmp_path: Path) -> None:
+    notice = version_check.check_for_updates(
+        installed_version="0.11.0",
+        cache_path=tmp_path / "v.json",
+        fetcher=lambda: "0.12.0",
+    )
+    assert notice is not None
+    assert "0.12.0" in notice
+    assert "0.11.0" in notice
+
+
+def test_check_for_updates_returns_none_when_up_to_date(tmp_path: Path) -> None:
+    notice = version_check.check_for_updates(
+        installed_version="0.11.0",
+        cache_path=tmp_path / "v.json",
+        fetcher=lambda: "0.11.0",
+    )
+    assert notice is None
+
+
+def test_check_for_updates_uses_cache_when_fresh(tmp_path: Path) -> None:
+    cache_path = tmp_path / "v.json"
+    version_check.save_cache(cache_path, "0.12.0")
+
+    calls = {"count": 0}
+
+    def fetcher() -> str | None:
+        calls["count"] += 1
+        return "0.99.0"  # Should not be reached.
+
+    notice = version_check.check_for_updates(
+        installed_version="0.11.0",
+        cache_path=cache_path,
+        fetcher=fetcher,
+    )
+    assert calls["count"] == 0
+    assert notice is not None
+    assert "0.12.0" in notice
+
+
+def test_check_for_updates_refreshes_stale_cache(tmp_path: Path) -> None:
+    cache_path = tmp_path / "v.json"
+    # Write a stale cache file by hand.
+    stale = {
+        "checked_at": (datetime.now().astimezone() - timedelta(days=7)).isoformat(),
+        "latest_version": "0.10.0",
+    }
+    cache_path.write_text(json.dumps(stale))
+
+    notice = version_check.check_for_updates(
+        installed_version="0.11.0",
+        cache_path=cache_path,
+        fetcher=lambda: "0.13.0",
+    )
+    assert notice is not None
+    assert "0.13.0" in notice
+
+    # Cache should be refreshed.
+    refreshed = version_check.load_cache(cache_path)
+    assert refreshed is not None
+    assert refreshed.latest_version == "0.13.0"
+
+
+def test_check_for_updates_returns_none_when_fetch_fails(tmp_path: Path) -> None:
+    notice = version_check.check_for_updates(
+        installed_version="0.11.0",
+        cache_path=tmp_path / "v.json",
+        fetcher=lambda: None,
+    )
+    assert notice is None
+
+
+def test_check_for_updates_swallows_fetcher_exceptions(tmp_path: Path) -> None:
+    def fetcher() -> str | None:
+        raise RuntimeError("network is down")
+
+    # Must not raise — a flaky network must never break the CLI.
+    notice = version_check.check_for_updates(
+        installed_version="0.11.0",
+        cache_path=tmp_path / "v.json",
+        fetcher=fetcher,
+    )
+    assert notice is None
+
+
+def test_check_for_updates_creates_cache_dir_if_missing(tmp_path: Path) -> None:
+    cache_path = tmp_path / "nested" / "dir" / "v.json"
+    version_check.check_for_updates(
+        installed_version="0.11.0",
+        cache_path=cache_path,
+        fetcher=lambda: "0.12.0",
+    )
+    assert cache_path.exists()
+
+
+# ── fetch_latest_version (network — mocked) ──────────────────────────
+
+
+def test_fetch_latest_version_parses_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    sample = b'[project]\nname = "rp"\nversion = "1.4.2"\n'
+
+    class FakeResponse:
+        def read(self) -> bytes:
+            return sample
+
+        def __enter__(self) -> FakeResponse:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    captured: dict[str, object] = {}
+
+    def fake_urlopen(req: object, timeout: float) -> FakeResponse:
+        captured["timeout"] = timeout
+        captured["url"] = getattr(req, "full_url", req)
+        return FakeResponse()
+
+    monkeypatch.setattr(version_check.urllib.request, "urlopen", fake_urlopen)
+
+    assert version_check.fetch_latest_version(timeout=1.5) == "1.4.2"
+    assert captured["timeout"] == 1.5
+    assert "raw.githubusercontent.com" in str(captured["url"])
+    assert "agencyenterprise/rp" in str(captured["url"])
+    assert "pyproject.toml" in str(captured["url"])
+
+
+def test_fetch_latest_version_returns_none_on_network_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def boom(*_args: object, **_kwargs: object) -> None:
+        raise OSError("connection refused")
+
+    monkeypatch.setattr(version_check.urllib.request, "urlopen", boom)
+    assert version_check.fetch_latest_version() is None
+
+
+# ── never blocks for too long ────────────────────────────────────────
+
+
+def test_check_for_updates_uses_short_default_timeout(tmp_path: Path) -> None:
+    """A slow fetcher must not block the CLI for noticeably long.
+
+    We don't actually call the network here; the fetcher is injected,
+    but this guards the design contract: check_for_updates is a thin
+    wrapper that should return promptly when the fetcher does.
+    """
+    start = time.monotonic()
+    version_check.check_for_updates(
+        installed_version="0.11.0",
+        cache_path=tmp_path / "v.json",
+        fetcher=lambda: "0.12.0",
+    )
+    assert time.monotonic() - start < 1.0
+
+
+# ── CLI wiring helper ────────────────────────────────────────────────
+
+
+def test_maybe_print_update_notice_writes_to_stderr(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from rp import main as rp_main
+
+    monkeypatch.delenv("RP_NO_VERSION_CHECK", raising=False)
+    monkeypatch.setattr(
+        rp_main,
+        "_check_for_updates_safe",
+        lambda: "A new version of rp is available: 0.11.0 → 0.12.0.",
+    )
+
+    rp_main._maybe_print_update_notice()
+
+    captured = capsys.readouterr()
+    assert "0.12.0" in captured.err
+    # Notice must not pollute stdout — pipelines often capture stdout.
+    assert captured.out == ""
+
+
+def test_maybe_print_update_notice_skips_when_env_set(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from rp import main as rp_main
+
+    monkeypatch.setenv("RP_NO_VERSION_CHECK", "1")
+
+    def boom() -> str | None:
+        raise AssertionError("must not be called when env var set")
+
+    monkeypatch.setattr(rp_main, "_check_for_updates_safe", boom)
+    rp_main._maybe_print_update_notice()
+
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert captured.out == ""
+
+
+def test_maybe_print_update_notice_skips_during_shell_completion(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Shell completion (typer) sets _RP_COMPLETE; printing breaks it."""
+    from rp import main as rp_main
+
+    monkeypatch.delenv("RP_NO_VERSION_CHECK", raising=False)
+    monkeypatch.setenv("_RP_COMPLETE", "complete_zsh")
+    monkeypatch.setattr(
+        rp_main,
+        "_check_for_updates_safe",
+        lambda: "A new version is available",
+    )
+
+    rp_main._maybe_print_update_notice()
+
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert captured.out == ""
+
+
+def test_maybe_print_update_notice_swallows_exceptions(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from rp import main as rp_main
+
+    monkeypatch.delenv("RP_NO_VERSION_CHECK", raising=False)
+
+    def boom() -> str | None:
+        raise RuntimeError("unexpected")
+
+    monkeypatch.setattr(rp_main, "_check_for_updates_safe", boom)
+
+    # Must not raise — the notice path is best-effort.
+    rp_main._maybe_print_update_notice()
+
+    captured = capsys.readouterr()
+    assert captured.err == ""

--- a/uv.lock
+++ b/uv.lock
@@ -1745,7 +1745,7 @@ wheels = [
 
 [[package]]
 name = "rp"
-version = "0.11.0"
+version = "0.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "pycares" },


### PR DESCRIPTION
## Summary

- After every command, `rp` checks `raw.githubusercontent.com/agencyenterprise/rp/main/pyproject.toml`, caches the result for 24h in `~/.config/rp/version_check.json`, and prints a one-line upgrade hint to stderr when the installed version is behind.
- Best-effort: any network/parse/FS error silently returns `None` — flaky connections never break a `rp` command. Skipped during shell completion (`_RP_COMPLETE`) and when `RP_NO_VERSION_CHECK=1`.
- Stdlib-only (`urllib.request` + `tomllib`) with a 2s timeout. A tiny dotted-numeric comparator avoids pulling `packaging` into the runtime closure.

The upgrade hint adapts: editable installs get `cd <repo> && git pull && uv pip install -e .`; wheel installs get a link to the GitHub repo.

## Test plan
- [x] `uv run pytest tests/unit/` — 196 passed (29 new)
- [x] `uv run ruff check` clean
- [x] Live `fetch_latest_version()` against the default branch returns the expected version
- [x] `RP_NO_VERSION_CHECK=1 rp --help` produces no notice
- [x] Verified the helper writes to stderr (so stdout-piping commands aren't polluted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)