### PR TITLE
Re-run full setup on managed pod resume

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ rp down h100-1 --destroy
 | Command | Description |
 |---|---|
 | `rp pod create [template] [--gpu] [--disk SIZE] [--storage SIZE] [--alias] [--note TEXT]` | Create bare pod, run setup.sh |
-| `rp pod start <alias>` | Resume stopped pod (re-injects secrets for managed pods) |
+| `rp pod start <alias>` | Resume stopped pod (re-runs full setup for managed pods, restoring the post-`rp up` state) |
 | `rp pod stop <alias>` | Stop pod |
 | `rp pod destroy <alias> [-f] [--all-sessions]` | Terminate pod permanently |
 | `rp pod track <pod_id_or_name> [alias]` | Track existing pod by ID or name |

--- a/docs.md
+++ b/docs.md
@@ -29,7 +29,7 @@ Create a pod with full opinionated setup. This is the recommended way to create 
 
 Uses `rp pod create` under the hood, then layers on: tool installation (uv, tmux, aws CLI, claude CLI, node), non-root `user` account (required by Claude CLI), secret injection from Keychain, and GPU idle auto-shutdown cron (120 min default).
 
-Managed pods are marked with `managed: true` in metadata. On `rp start`, managed pods get secrets re-injected and auto-shutdown redeployed.
+Managed pods are marked with `managed: true` in metadata. On `rp pod start`, managed pods re-run the full setup (tools, non-root user, secrets, auto-shutdown). This restores the post-`rp up` state because a RunPod stop/start can rebuild the container filesystem — only `/workspace` is guaranteed to persist — so system-level tools and the `user` account may be gone. The setup steps are idempotent, so resuming a pod whose filesystem did survive only re-checks them.
 
 The tool-install step waits for cloud-init / unattended-upgrades to release the dpkg lock before running apt, and the whole step is retried up to 3× (30s backoff) on transient apt failures (exit 100 / "Could not get lock"). When something does fail, the full transcript is teed to `/tmp/rp-setup.log` on the pod — `ssh <alias> 'cat /tmp/rp-setup.log'` for post-mortem.
 
@@ -194,7 +194,7 @@ rp pod create h100 --note "AE-5678: pretraining run"               # annotate po
 
 #### `rp pod start <alias>`
 
-Resume a stopped pod. Updates SSH config. For managed pods, re-injects secrets and redeploys auto-shutdown. For bare pods, re-runs setup script.
+Resume a stopped pod. Updates SSH config. For managed pods, re-runs the full opinionated setup (tools, non-root user, secrets, auto-shutdown) so the pod returns to the same state `rp up` would leave it in — necessary because a stop/start can reset the container filesystem (only `/workspace` persists). Setup steps are idempotent. Pass `--no-setup` to skip this. For bare pods, re-runs the setup script.
 
 #### `rp pod stop <alias>`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rp"
-version = "0.13.1"
+version = "0.13.2"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/rp/cli/commands.py
+++ b/src/rp/cli/commands.py
@@ -548,10 +548,15 @@ def start_command(alias: str | None, no_setup: bool = False) -> None:
         elif metadata and metadata.managed:
             from rp.core.pod_setup import PodSetup
 
-            console.print("⚙️  Re-running managed setup…")
+            console.print("⚙️  Re-provisioning pod…")
             warn_secret_mismatches()
             setup = PodSetup(alias, pod.id, console)
-            setup.run_managed_restart_setup()
+            # Full setup, not a secrets-only subset: a resumed pod can come back
+            # on a fresh container filesystem (only /workspace survives a RunPod
+            # stop/start), so tools and the non-root user must be reinstalled to
+            # restore the post-`rp up` state. Steps are idempotent, so this is
+            # cheap when the filesystem did persist.
+            setup.run_full_setup()
         else:
             # Run legacy setup scripts for non-managed pods
             run_setup_scripts(alias)

--- a/src/rp/core/pod_setup.py
+++ b/src/rp/core/pod_setup.py
@@ -43,13 +43,6 @@ class PodSetup:
             self.inject_secrets()
             self.deploy_auto_shutdown()
 
-    def run_managed_restart_setup(self) -> None:
-        """Re-run setup needed after a managed pod restarts (secrets + auto-shutdown)."""
-        with self._wrap_setup_errors():
-            self._wait_for_ssh()
-            self.inject_secrets()
-            self.deploy_auto_shutdown()
-
     @contextmanager
     def _wrap_setup_errors(self):
         """Convert raw ssh CalledProcessError to SetupScriptError so the

--- a/tests/unit/test_start_command.py
+++ b/tests/unit/test_start_command.py
@@ -1,0 +1,72 @@
+"""rp pod start re-provisions managed pods with the full setup.
+
+A stopped pod can come back on a fresh container filesystem (only /workspace
+survives a RunPod stop/start), so resume must reinstall tools and recreate the
+non-root user — i.e. run the full setup, not a secrets-only subset.
+"""
+
+from unittest.mock import MagicMock, patch
+
+
+def _managed_pm(*, managed: bool):
+    pm = MagicMock()
+    pod = MagicMock()
+    pod.id = "pod-1"
+    pod.ip_address = "1.2.3.4"
+    pod.ssh_port = 22
+    pm.start_pod.return_value = pod
+    pm.config.pod_metadata.get.return_value = MagicMock(managed=managed)
+    return pm
+
+
+def test_start_managed_pod_runs_full_setup(temp_config_dir):  # noqa: ARG001
+    from rp.cli import commands
+
+    with (
+        patch.object(
+            commands, "get_pod_manager", return_value=_managed_pm(managed=True)
+        ),
+        patch.object(commands, "get_ssh_manager"),
+        patch.object(commands, "warn_secret_mismatches"),
+        patch.object(commands, "_auto_clean"),
+        patch("rp.core.pod_setup.PodSetup") as PodSetup,
+    ):
+        commands.start_command("foo")
+
+    setup = PodSetup.return_value
+    setup.run_full_setup.assert_called_once_with()
+
+
+def test_start_managed_pod_no_setup_skips_setup(temp_config_dir):  # noqa: ARG001
+    from rp.cli import commands
+
+    with (
+        patch.object(
+            commands, "get_pod_manager", return_value=_managed_pm(managed=True)
+        ),
+        patch.object(commands, "get_ssh_manager"),
+        patch.object(commands, "warn_secret_mismatches"),
+        patch.object(commands, "_auto_clean"),
+        patch("rp.core.pod_setup.PodSetup") as PodSetup,
+    ):
+        commands.start_command("foo", no_setup=True)
+
+    PodSetup.assert_not_called()
+
+
+def test_start_bare_pod_runs_legacy_setup_scripts(temp_config_dir):  # noqa: ARG001
+    from rp.cli import commands
+
+    with (
+        patch.object(
+            commands, "get_pod_manager", return_value=_managed_pm(managed=False)
+        ),
+        patch.object(commands, "get_ssh_manager"),
+        patch.object(commands, "_auto_clean"),
+        patch.object(commands, "run_setup_scripts") as run_setup_scripts,
+        patch("rp.core.pod_setup.PodSetup") as PodSetup,
+    ):
+        commands.start_command("foo")
+
+    run_setup_scripts.assert_called_once_with("foo")
+    PodSetup.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -1745,7 +1745,7 @@ wheels = [
 
 [[package]]
 name = "rp"
-version = "0.13.1"
+version = "0.13.2"
 source = { editable = "." }
 dependencies = [
     { name = "pycares" },


### PR DESCRIPTION
## Problem

`rp pod start` was meant to restore a managed pod to its post-`rp up` state, but it ran a secrets-only restart path (`run_managed_restart_setup`) that skipped tool install and non-root user creation — on the assumption those survive a stop/start.

They don't. RunPod only guarantees the `/workspace` volume persists; the container filesystem can be rebuilt on resume, wiping `sudo`, the apt tools, and the `user` account. That breaks `rp run`, which wraps commands as `sudo -u user …` — the failure mode that prompted this fix was a resumed pod reporting `sudo: command not found`.

## Fix

- `rp pod start` now runs the full, idempotent `run_full_setup()` for managed pods, restoring the true post-`rp up` state. The `command -v` / `id -u` guards keep it cheap when the filesystem *did* survive.
- Removed the now-dead `run_managed_restart_setup()` (this matches what `rp setup` already does for managed pods).
- `--no-setup` still skips setup; bare pods still run the legacy setup script.

## Tests / docs

- 3 new unit tests covering the managed full-setup path, `--no-setup`, and the bare-pod path.
- Updated `docs.md` and `README.md`; bumped version to `0.13.2`.
- All 248 unit tests pass; ruff + pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)